### PR TITLE
Fix folder detection name

### DIFF
--- a/plugin.video.fs.ua/default.py
+++ b/plugin.video.fs.ua/default.py
@@ -698,7 +698,7 @@ def read_dir(params):
 
 
 def add_directory_item(linkItem, isFolder, playLink, playLinkClass, cover, folderUrl, folder, isMusic, quality = None, itemsCount = None):
-    folderRegexp = re.compile('(\d+)')
+    folderRegexp = re.compile('(\d+|language[:\d]+|translation[:\d]+)')
     lang = None
     langRegexp = re.compile('\s*m\-(\w+)\s*')
     lang_data = langRegexp.findall(linkItem['class'])


### PR DESCRIPTION
Fix the problem in #24
The main problem appeared due to incorrect parsing of folder name and passing it to the list of folders

Fix the issue for language folders and for translation folders

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seppius-xbmc-repo/ru/25)
<!-- Reviewable:end -->
