### PR TITLE
Improve #25 fix for serials

### DIFF
--- a/plugin.video.fs.ua/default.py
+++ b/plugin.video.fs.ua/default.py
@@ -698,7 +698,7 @@ def read_dir(params):
 
 
 def add_directory_item(linkItem, isFolder, playLink, playLinkClass, cover, folderUrl, folder, isMusic, quality = None, itemsCount = None):
-    folderRegexp = re.compile('(\d+|language[:\d]+|translation[:\d]+)')
+    folderRegexp = re.compile('(\d+|language[:\d]+|translation[:\d]+|season[:\d]+)')
     lang = None
     langRegexp = re.compile('\s*m\-(\w+)\s*')
     lang_data = langRegexp.findall(linkItem['class'])


### PR DESCRIPTION
I noticed that #25 wasn't fully fixed, serial's folders like 'Сезон 1', 'Сезон 2' etc still cannot be opened.
This fix resolve this problem for sure...

@x86demon please review...  @sshnaidm please merge when LGTM will be got
I hope it will be the last fix for this problem )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seppius-xbmc-repo/ru/26)
<!-- Reviewable:end -->
