### PR TITLE
Add missing dir XML node

### DIFF
--- a/repository.GRecoTM/addon.xml
+++ b/repository.GRecoTM/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.GRecoTM" name=" GRecoTM Repository" version="2.2" provider-name="GRecoTM">
 	<extension point="xbmc.addon.repository" name="GRecoTM Repository">
+		<dir>
 		<info compressed="false">http://grrepo.grecotm.com/Plugins/addons.xml</info>
 		<checksum>http://grrepo.grecotm.com/Plugins/addons.xml.md5</checksum>
 		<datadir zip="true">http://grrepo.grecotm.com/Plugins/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>GRecoTM Repository</summary>

--- a/repository.arneson/addon.xml
+++ b/repository.arneson/addon.xml
@@ -4,10 +4,12 @@
         <import addon="xbmc.addon" version="12.0.0"/>
     </requires>
     <extension point="xbmc.addon.repository" name="TIDAL2 Addons by arneson">
+        <dir>
         <info compressed="false">https://github.com/arnesongit/repository.arneson/raw/master/addons.xml</info>
         <checksum>https://github.com/arnesongit/repository.arneson/raw/master/addons.xml.md5</checksum>
         <datadir zip="true">https://github.com/arnesongit/repository.arneson/raw/master</datadir>
         <hashes>false</hashes>
+        </dir>
     </extension>
     <extension point="xbmc.addon.metadata">
         <summary>Install TIDAL2 Addons by arneson</summary>

--- a/repository.const/addon.xml
+++ b/repository.const/addon.xml
@@ -7,9 +7,11 @@
   <import addon="xbmc.addon" version="12.0.0"/>
 </requires>	
 	<extension point="xbmc.addon.repository" name="Const Kodi Add-ons">
+		<dir>
 		<info compressed="false">https://github.com/const586/const-kodi-repo/raw/master/addons/addons.xml</info>
 		<checksum>https://github.com/const586/const-kodi-repo/raw/master/addons/addons.xml.md5</checksum>
 		<datadir zip="true">https://github.com/const586/const-kodi-repo/raw/master/addons</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Install Add-ons from const Add-on Repository</summary>

--- a/repository.dandy.kodi/addon.xml
+++ b/repository.dandy.kodi/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.dandy.kodi" name="Dandy's Kodi Repository" version="1.0.5" provider-name="dandy">
 	<extension point="xbmc.addon.repository" name="Dandy Kodi Add-ons Repository">
+		<dir>
 		<info compressed="false">https://raw.github.com/dandygithub/kodi/master/addons/addons.xml</info>
 		<checksum>https://raw.github.com/dandygithub/kodi/master/addons/addons.xml.md5</checksum>
 		<datadir zip="true">https://raw.github.com/dandygithub/kodi/master/addons/zip/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Install Add-ons by Dandy add-on repository</summary>

--- a/repository.dvor85/addon.xml
+++ b/repository.dvor85/addon.xml
@@ -4,9 +4,11 @@
 	   version="1.0.0" 
 	   provider-name="dvor85">
 	<extension point="xbmc.addon.repository" name="dvor85 XBMC Add-ons">
+		<dir>
 		<info compressed="false">https://github.com/dvor85/kodi.repo/raw/master/addons.xml</info>
 		<checksum>https://github.com/dvor85/kodi.repo/raw/master/addons.xml.md5</checksum>
 		<datadir zip="true">https://github.com/dvor85/kodi.repo/raw/master/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Install Add-ons from RUS Add-on Repository</summary>

--- a/repository.evgen_dev/addon.xml
+++ b/repository.evgen_dev/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.evgen_dev" name="Evgen_dev XBMC Add-ons" version="2.0.0" provider-name="evgen_dev">
 	<extension point="xbmc.addon.repository" name="Evgen_dev XBMC Add-ons">
+		<dir>
 		<info compressed="false">https://raw.githubusercontent.com/evgen-dev/repository.evgen_dev.xbmc-addons/master/addons.xml?v=1</info>
 		<checksum>https://raw.githubusercontent.com/evgen-dev/repository.evgen_dev.xbmc-addons/master/addons.xml.md5?v=1</checksum>
 		<datadir zip="true">https://raw.githubusercontent.com/evgen-dev/repository.evgen_dev.xbmc-addons/master/repo</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Дополнения из репозитория evgen_dev</summary>

--- a/repository.hal9000/addon.xml
+++ b/repository.hal9000/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.hal9000" name="HAL9000 Add-on Repository" version="1.0.1" provider-name="HAL9000">
     <extension point="xbmc.addon.repository" name="HAL9000 Add-on Repository">
+        <dir>
         <info compressed="false">https://raw.githubusercontent.com/xbmc-addon/repository.hal9000/master/addons.xml</info>
         <checksum>https://raw.githubusercontent.com/xbmc-addon/repository.hal9000/master/addons.xml.md5</checksum>
         <datadir zip="true">https://raw.githubusercontent.com/xbmc-addon/repository.hal9000/master/repo</datadir>
+        </dir>
     </extension>
     <extension point="xbmc.addon.metadata">
         <summary lang="en">Install HAL9000 Addons</summary>

--- a/repository.kodi-senyor/addon.xml
+++ b/repository.kodi-senyor/addon.xml
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.kodi-senyor" name="kodi senyor repository" version="1.2.1" provider-name="kodi senyor">
 	<extension point="xbmc.addon.repository" name="kodi senyor repository">
+		<dir>
 			<info compressed="false">https://github.com/kobiko3030/repository.kodisenyor/raw/master/addons.xml</info>
 			<checksum>https://github.com/kobiko3030/repository.kodisenyor/raw/master/addons.xml.md5</checksum>
 			<datadir zip="true">https://github.com/kobiko3030/repository.kodisenyor/raw/master/Zips/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en">kodi-senyor.co.il repo</summary>

--- a/repository.kodil/addon.xml
+++ b/repository.kodil/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.kodil" name=".[COLOR blue].Kodil [/COLOR][COLOR white] Repository [/COLOR]" version="1.3" provider-name="kodil">
     <extension point="xbmc.addon.repository" name=".Kodil  Repository ">
+        <dir>
         <info compressed="false">https://raw.githubusercontent.com/kodil/kodil/master/addons.xml</info>
         <checksum>https://raw.githubusercontent.com/kodil/kodil/master/addons.xml.md5</checksum>
         <datadir zip="true">https://raw.githubusercontent.com/kodil/kodil/master/repo</datadir>
+        </dir>
     </extension>
     <extension point="xbmc.addon.metadata">
         <summary>kodisrael repository</summary>

--- a/repository.magnetic.mirror/addon.xml
+++ b/repository.magnetic.mirror/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.magnetic.mirror" name="[COLOR FFFFD800]Magnetic[/COLOR] Mirror Repository" version="0.1.2" provider-name="mancuniancol">
 	<extension point="xbmc.addon.repository" name="Magnetic Repository">
+       <dir>
        <info>https://svn.riouxsvn.com/magnetic/addons.xml</info>
        <checksum>https://svn.riouxsvn.com/magnetic//addons.xml.md5</checksum>
        <datadir zip="true">https://svn.riouxsvn.com/magnetic/</datadir>
+       </dir>
 	</extension>		
 	<extension point="xbmc.addon.metadata">
 		<summary>Magnetic Module and Parsers</summary>

--- a/repository.merlin/addon.xml
+++ b/repository.merlin/addon.xml
@@ -4,9 +4,11 @@
             <import addon="xbmc.addon" version="12.0.0"/>
         </requires>
 		<extension point="xbmc.addon.repository" name="Merlin Repository">
+			<dir>
 			<info compressed="false">http://mrepo.uk/merlinrepo/addons.xml</info>
 			<checksum>http://mrepo.uk/merlinrepo/addons.xml.md5</checksum>
 			<datadir zip="true">http://mrepo.uk/merlinrepo/addons/</datadir>
+			</dir>
 		</extension>
 		<extension point="xbmc.addon.metadata">
 			<summary>Host Of Add-Ons And Repositories</summary>

--- a/repository.mnn/addon.xml
+++ b/repository.mnn/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.mnn" name="MNN Xbmc Add-ons" version="1.0.3" provider-name="MazurokNN">
 	<extension point="xbmc.addon.repository" name="MNN Xbmc Add-ons">
+		<dir>
 		<info compressed="false">https://github.com/snakefishh/mnn-xbmc-repo/raw/master/addons.xml</info>
 		<checksum>https://github.com/snakefishh/mnn-xbmc-repo/raw/master/addons.xml.md5</checksum>
 		<datadir zip="true">https://github.com/snakefishh/mnn-xbmc-repo/raw/master/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Install Add-ons from MNN Add-on Repository</summary>

--- a/repository.myshows.me/addon.xml
+++ b/repository.myshows.me/addon.xml
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.myshows.me" name="MyShows.me Kodi Repo" version="1.0.7" provider-name="DiMartino">
 	<extension point="xbmc.addon.repository" name="MyShows.me Kodi Repo">
+		<dir>
 		<info compressed="true">https://raw.github.com/DiMartinoX/repository.myshows.me/master/repo/addons.xml</info>
 		<checksum>https://raw.github.com/DiMartinoX/repository.myshows.me/master/repo/addons.xml.md5</checksum>
 		<datadir zip="true">https://raw.github.com/DiMartinoX/repository.myshows.me/master/repo/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Устанавливайте дополнения из репозитория MyShows.me</summary>

--- a/repository.romanvm/addon.xml
+++ b/repository.romanvm/addon.xml
@@ -10,8 +10,10 @@
   <platform>all</platform>
 </extension>
 <extension point="xbmc.addon.repository" name="romanvm repository">
+  <dir>
   <info compressed="false">http://romanvm.github.io/kodi_repo/repo/addons.xml</info>
   <checksum>http://romanvm.github.io/kodi_repo/repo/addons.xml.md5</checksum>
   <datadir zip="true">http://romanvm.github.io/kodi_repo/repo</datadir>
+  </dir>
 </extension>
 </addon>

--- a/repository.rvlad1987/addon.xml
+++ b/repository.rvlad1987/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.rvlad1987" name="RVlad1987 Kodi Add-ons" version="1.0.1" provider-name="rvlad1987">
 	<extension point="xbmc.addon.repository" name="RVlad1987 Kodi Add-ons">
+		<dir>
 		<info compressed="false">https://raw.githubusercontent.com/rvlad1987/repository.rvlad1987.xbmc-addons/master/addons.xml</info>
 		<checksum>https://raw.githubusercontent.com/rvlad1987/repository.rvlad1987.xbmc-addons/master/addons.xml.md5</checksum>
 		<datadir zip="true">https://raw.githubusercontent.com/rvlad1987/repository.rvlad1987.xbmc-addons/master/repo</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Дополнения из репозитория rvlad1987</summary>

--- a/repository.seppius/addon.xml
+++ b/repository.seppius/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.seppius" name="Seppius XBMC Add-ons" version="1.0.1" provider-name="seppius">	
 	<extension point="xbmc.addon.repository" name="Seppius XBMC Add-ons">
+		<dir>
 		<info compressed="false">https://github.com/seppius-xbmc-repo/ru/raw/master/addons.xml</info>
 		<checksum>https://github.com/seppius-xbmc-repo/ru/raw/master/addons.xml.md5</checksum>
 		<datadir zip="true">https://github.com/seppius-xbmc-repo/ru/raw/master/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Install Add-ons from RUS Add-on Repository</summary>

--- a/repository.silhouette/addon.xml
+++ b/repository.silhouette/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.silhouette" name="Silhouette XBMC Add-ons" version="2.0.4" provider-name="Silhouette">
 	<extension point="xbmc.addon.repository" name="Silhouette XBMC Add-ons">
+		<dir>
 		<info compressed="false">https://raw.githubusercontent.com/silhouette2022/kodi/master/addons.xml</info>
 		<checksum>https://raw.githubusercontent.com/silhouette2022/kodi/master/addons.xml.md5</checksum>
 		<datadir zip="true">https://raw.githubusercontent.com/silhouette2022/kodi/master/repo</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Install Add-ons from Silhouette Add-on Repository</summary>

--- a/repository.srg70/addon.xml
+++ b/repository.srg70/addon.xml
@@ -8,8 +8,10 @@
   <platform>all</platform>
 </extension>
 <extension point="xbmc.addon.repository" name="srg70 repository">
+  <dir>
   <info compressed="false">https://github.com/srg70/kodi_repo/raw/master/repo/addons.xml</info>
   <checksum>https://github.com/srg70/kodi_repo/raw/master/repo/addons.xml.md5</checksum>
   <datadir zip="true">https://github.com/srg70/kodi_repo/raw/master/repo</datadir>
+  </dir>
 </extension>
 </addon>

--- a/repository.uzzer-dev/addon.xml
+++ b/repository.uzzer-dev/addon.xml
@@ -4,10 +4,12 @@
             <import addon="xbmc.addon" version="12.0.0"/>
         </requires>
         <extension point="xbmc.addon.repository" name="Uzzer Kodi Addons">
+            <dir>
             <info compressed="false">https://notabug.org/d3c_d3v/AddonRepo/raw/master/_repo/addons.xml</info>
             <checksum>https://notabug.org/d3c_d3v/AddonRepo/raw/master/_repo/addons.xml.md5</checksum>
             <datadir zip="true">https://notabug.org/d3c_d3v/AddonRepo/raw/master/_repo/</datadir>
             <hashes>false</hashes>
+            </dir>
         </extension>
         <extension point="xbmc.addon.metadata">
             <summary>Repo for my addons</summary>

--- a/repository.vd/addon.xml
+++ b/repository.vd/addon.xml
@@ -8,8 +8,10 @@
   <platform>all</platform>
 </extension>
 <extension point="xbmc.addon.repository" name="Vd's repository">
+  <dir>
   <info compressed="false">https://bitbucket.org/vadyur/kodi_repo/raw/master/repo/addons.xml</info>
   <checksum>https://bitbucket.org/vadyur/kodi_repo/raw/master/repo/addons.xml.md5</checksum>
   <datadir zip="true">https://bitbucket.org/vadyur/kodi_repo/raw/master/repo</datadir>
+  </dir>
 </extension>
 </addon>

--- a/repository.virserg/addon.xml
+++ b/repository.virserg/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.virserg" name="Virserg Repository" version="1.0.0" provider-name="Virserg">
     <extension point="xbmc.addon.repository" name="Virserg Repository">
+        <dir>
         <info compressed="false">https://raw.githubusercontent.com/virserg/kodirepo/master/addons.xml</info>
         <checksum>https://raw.githubusercontent.com/virserg/kodirepo/master/addons.xml.md5</checksum>
         <datadir zip="true">https://raw.githubusercontent.com/virserg/kodirepo/master/zips</datadir>
+        </dir>
     </extension>
     <extension point="xbmc.addon.metadata">
         <summary lang="en">Install Addons</summary>

--- a/repository.vlmaksime/addon.xml
+++ b/repository.vlmaksime/addon.xml
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.vlmaksime" name="vl.maksime Add-on repository" version="2.0.0" provider-name="vl.maksime">
     <extension point="xbmc.addon.repository">
+        <dir>
         <info>https://vlmaksime.github.io/repository.vlmaksime/addons.xml</info>
         <checksum>https://vlmaksime.github.io/repository.vlmaksime/addons.xml.md5</checksum>
         <datadir zip="true">https://vlmaksime.github.io/repository.vlmaksime/releases/</datadir>
+        </dir>
     </extension>
     <extension point="xbmc.addon.metadata">
         <summary lang="en">Install Add-ons from vl.maksime</summary>

--- a/repository.xbmc-israel/addon.xml
+++ b/repository.xbmc-israel/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.xbmc-israel" name=".[COLOR blue]XBMC Israeli [/COLOR][COLOR white] Streaming Sites[/COLOR]" version="1.0.4" provider-name="cubicle-vdo">
     <extension point="xbmc.addon.repository" name="XBMC Israeli streaming repo for streaming sites">
+        <dir>
         <info compressed="false">https://raw.githubusercontent.com/cubicle-vdo/xbmc-israel/master/addons.xml</info>
         <checksum>https://raw.githubusercontent.com/cubicle-vdo/xbmc-israel/master/addons.xml.md5</checksum>
         <datadir zip="true">https://raw.githubusercontent.com/cubicle-vdo/xbmc-israel/master/repo</datadir>
+        </dir>
     </extension>
     <extension point="xbmc.addon.metadata">
         <summary>XBMC Israeli Streaming Sites</summary>

--- a/repository.xxtrep/addon.xml
+++ b/repository.xxtrep/addon.xml
@@ -7,9 +7,11 @@
   <import addon="xbmc.addon" version="12.0.0"/>
 </requires>	
 	<extension point="xbmc.addon.repository" name="XXTREP XBMC Add-ons">
+		<dir>
 		<info compressed="false">https://github.com/taifxx/xxtrep/raw/master/addons.xml</info>
 		<checksum>https://github.com/taifxx/xxtrep/raw/master/addons.xml.md5</checksum>
 		<datadir zip="true">https://github.com/taifxx/xxtrep/raw/master/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary>Install Add-ons from XXTREP Add-on Repository</summary>

--- a/repository.yatse.kodi/addon.xml
+++ b/repository.yatse.kodi/addon.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.kodi.yatse.tv" name="Yatse Kodi Add-on repository" version="1.0.1" provider-name="Yatse">
 	<extension point="xbmc.addon.repository" name="Yatse Kodi Add-on repository">
+		<dir>
 		<info compressed="false">https://raw.githubusercontent.com/Tolriq/repository.yatse.kodi/master/zips/addons.xml</info>
 		<checksum>https://raw.githubusercontent.com/Tolriq/repository.yatse.kodi/master/zips/addons.xml.md5</checksum>
 		<datadir zip="true">https://raw.githubusercontent.com/Tolriq/repository.yatse.kodi/master/zips/</datadir>
+		</dir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en">Yatse repository for Kodi helper addons</summary>


### PR DESCRIPTION
The new versions of Kodi dropped support for repository attribute XML without dir node. Add it.